### PR TITLE
Trackball renders under openscad nightly

### DIFF
--- a/hardware/trackball.scad
+++ b/hardware/trackball.scad
@@ -1,6 +1,6 @@
 
 // This module prints the full trackball body, with all cutouts.
-// full();
+full();
 
 // This prints the bottom plate. To use it, comment out full() above and uncomment this line.
 // The first argument is the thickness of the bottom cover in mm. I recommend at least 3, for structural integrity.
@@ -741,7 +741,7 @@ module body_right_rear_cut(params)
     rotate([-params[2], 0, 0])
     union()
     {
-        rotate_extrude(angle=-180)
+        rotate_extrude()
         intersection()
         {  
             offset(-params[6]) 


### PR DESCRIPTION
Closes #2

I don't see a difference in the model before and after, but I am still
getting used to how this design looks.

The reason why I wanted this:

```
$ time openscad hardware/trackball.scad -o trackball.stl # OpenSCAD version 2019.05
...
real    6m7.033s
user    6m5.835s
sys     0m1.136s

$ time openscad-nightly hardware/trackball.scad -o trackball.stl # OpenSCAD version 2022.02.10.nightly
...
real    4m43.469s
user    4m42.785s
sys     0m0.676s

$ time openscad-nightly --enable=fast-csg hardware/trackball.scad -o trackball.stl # OpenSCAD version 2022.02.10.nightly
...
real    0m40.240s
user    0m39.265s
sys     0m0.968s
```

see https://ochafik.com/jekyll/update/2022/02/09/openscad-fast-csg-contibution.html for more information